### PR TITLE
Feat: List 컴포넌트 생성

### DIFF
--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -1,0 +1,57 @@
+import PropTypes from "prop-types";
+import EmptyStar from "../assets/empty_star.svg";
+import FullStar from "../assets/full_star.svg";
+import { useState } from "react";
+
+const page = window.location.pathname.split("/")[1];
+
+export const List = ({ title, participantsCount, isBookmarked }) => {
+  const [isClickBookmarked, setIsClickBookmarked] = useState(isBookmarked);
+
+  const handlerClickStar = () => {
+    setIsClickBookmarked(!isClickBookmarked);
+  };
+
+  const handlerClickList = () => {};
+
+  const handlerClickTrash = () => {};
+
+  return (
+    <div
+      className="flex justify-between items-center w-full h-[8vh] p-5 my-3 bg-white rounded-lg border-[0.5px] border-gray shadow hover:cursor-pointer hover:shadow-sm"
+      onClick={handlerClickList}
+    >
+      <div className="flex gap-5 items-center">
+        {page === "" ? (
+          <div onClick={handlerClickStar}>
+            <svg width="35" height="35" viewBox="0 0 40 40">
+              {isClickBookmarked ? <FullStar /> : <EmptyStar />}
+            </svg>
+          </div>
+        ) : (
+          <span className="m-[-0.5rem]"></span>
+        )}
+        <p className="nps-bold text-lg">{title}</p>
+      </div>
+      {page === "" ? (
+        <span
+          className="material-symbols-outlined text-2xl hover:text-3xl"
+          onClick={handlerClickTrash}
+        >
+          delete
+        </span>
+      ) : (
+        <div className="flex items-center gap-1">
+          <span className="material-symbols-outlined text-2xl">groups</span>
+          <span className="text-lg">{participantsCount}</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+List.propTypes = {
+  title: PropTypes.string,
+  participantsCount: PropTypes.number,
+  isBookmarked: PropTypes.bool,
+};


### PR DESCRIPTION
## 📝 작업 내용

<img width="734" alt="image" src="https://github.com/moofarm/ssuckssuck-frontend/assets/74824057/d6287655-2bfa-4a0b-8802-d4d095ed98de">


## 🔗 연관 이슈

#15 

## ✅ 리뷰 요구사항

- 아직 페이지 라우팅이 구현 되지 않아서 "나의미션방"에 있을 때와 "전체미션방"에 있을 때를 구분하지 못합니다.
- 모달과 페이지 라우팅이 완성되면 이어서 구현 하겠습니다!
- 백엔드에서 북마크 된 리스트와 아닌 리스트를 구분해서 보내주기로 했습니다.

디자인 피드백도 부탁 드려요 :)
*active시 효과는 따로 없고 hover시에는 shadow -> shodow-sm 정도로 효과를 주었습니다!