### PR TITLE
Feat: 검색 컴포넌트 생성

### DIFF
--- a/src/components/SearchContainer.jsx
+++ b/src/components/SearchContainer.jsx
@@ -1,0 +1,18 @@
+const SearchContainer = () => {
+  return (
+    <div className="absolute top-0 left-0 w-screen h-screen bg-white">
+      <div className="w-3/4 m-auto flex flex-col">
+        <span className="material-symbols-outlined self-end my-5 cursor-pointer">close</span>
+        <div className="flex items-center border-[0.5px] border-gray rounded-md p-3">
+          <span className="material-symbols-outlined">search</span>
+          <input
+            placeholder="검색할 키워드를 입력하세요."
+            className="border-none outline-none w-full pl-3"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SearchContainer;


### PR DESCRIPTION
## 📝 작업 내용
<img width="1440" alt="image" src="https://github.com/moofarm/ssuckssuck-frontend/assets/74824057/5a7e9da1-3279-4b0d-8834-51c697543c9d">


## 🔗 연관 이슈

#21 

## ✅ 리뷰 요구사항

- 검색 컴포넌트의 컴포넌트명을 고민하다가 `SearchContainer`로 했는데 더 좋은 아이디어가 있다면 알려주세요..
- 기존의 계획에서는 검색 컴포넌트 부분이 반투명 흰색으로 하려고 했는데 막상 만들어 보니 검색창 뒤에 화면이 비춰서 가독성이 떨어지고 안예쁜 것 같아서 그냥 완전 흰색 배경으로 바꿨습니다!
- 아직 검색 API를 불러올 수 없어서 일단 develop에 합치고 차후에 추가 개발 해야 할 것 같습니다!!

확인 해주세요~~
